### PR TITLE
Adds empty? for NSAttributedString

### DIFF
--- a/lib/cocoa/sugarcube-attributedstring/nsattributedstring.rb
+++ b/lib/cocoa/sugarcube-attributedstring/nsattributedstring.rb
@@ -115,6 +115,24 @@ class NSAttributedString
     self.length == 0
   end
 
+  def strip
+    # Trim leading whitespace and newlines.
+    charSet = NSCharacterSet.whitespaceAndNewlineCharacterSet
+    range = self.string.rangeOfCharacterFromSet(charSet)
+    while (range.length != 0 && range.location == 0)
+      self.replaceCharactersInRange(range, withString:"")
+      range = self.string.rangeOfCharacterFromSet(charSet)
+    end
+
+    # Trim trailing whitespace and newlines.
+    range = self.string.rangeOfCharacterFromSet(charSet, options:NSBackwardsSearch)
+    while (range.length != 0 && NSMaxRange(range) == self.length)
+      self.replaceCharactersInRange(range, withString:"")
+      range = self.string.rangeOfCharacterFromSet(charSet, options:NSBackwardsSearch)
+    end
+    self
+  end
+
 end
 
 

--- a/lib/cocoa/sugarcube-attributedstring/nsattributedstring.rb
+++ b/lib/cocoa/sugarcube-attributedstring/nsattributedstring.rb
@@ -111,6 +111,10 @@ class NSAttributedString
     string
   end
 
+  def empty?
+    self.length == 0
+  end
+
 end
 
 

--- a/spec/cocoa/nsattributedstring_spec.rb
+++ b/spec/cocoa/nsattributedstring_spec.rb
@@ -37,6 +37,11 @@ describe 'NSAttributeString' do
       'test'.attrd.vertical_glyph_form(1).should.have_string_attributes({ NSVerticalGlyphFormAttributeName => 1 })
     end
 
+    it 'should have have `empty?`' do
+      'test'.attrd.empty?.should == false
+      ''.attrd.empty?.should == true
+    end
+
   end
 
 end

--- a/spec/cocoa/nsattributedstring_spec.rb
+++ b/spec/cocoa/nsattributedstring_spec.rb
@@ -42,6 +42,19 @@ describe 'NSAttributeString' do
       ''.attrd.empty?.should == true
     end
 
+    it 'should have `strip`' do
+      'test '.attrd.strip.should == 'test'.attrd
+      ' test '.attrd.strip.should == 'test'.attrd
+      ' test'.attrd.strip.should == 'test'.attrd
+      "\ntest".attrd.strip.should == 'test'.attrd
+      "\n test".attrd.strip.should == 'test'.attrd
+      "\n test \n".attrd.strip.should == 'test'.attrd
+      "\n test  \n".attrd.strip.should == 'test'.attrd
+      "test  ".attrd.strip.should == 'test'.attrd
+      "test\n  ".attrd.strip.should == 'test'.attrd
+      "  \n test".attrd.strip.should == 'test'.attrd
+    end
+
   end
 
 end


### PR DESCRIPTION
```ruby
"".empty? == true
# but
"".attrd.empty? == true
# undefined method `empty?' for  :NSConcreteMutableAttributedString
```

Wondering if this should be added to RM core? Think I should file a bug report or no?