### PR TITLE
NSColor on 10.8

### DIFF
--- a/lib/osx/sugarcube-color/fixnum.rb
+++ b/lib/osx/sugarcube-color/fixnum.rb
@@ -16,7 +16,11 @@ class Fixnum
     green = ((self & 0xFF00) >> 8).to_f / 255.0
     blue = (self & 0xFF).to_f / 255.0
 
-    NSColor.colorWithRed(red, green: green, blue: blue, alpha: alpha.to_f)
+    if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
+      NSColor.colorWithRed(red, green: green, blue: blue, alpha: alpha.to_f)
+    else
+      NSColor.colorWithCalibratedRed(red, green:green, blue:blue, alpha:alpha.to_f)
+    end
   end
 
   def cgcolor(alpha=nil)

--- a/lib/osx/sugarcube-color/fixnum.rb
+++ b/lib/osx/sugarcube-color/fixnum.rb
@@ -16,11 +16,7 @@ class Fixnum
     green = ((self & 0xFF00) >> 8).to_f / 255.0
     blue = (self & 0xFF).to_f / 255.0
 
-    if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
-      NSColor.colorWithRed(red, green: green, blue: blue, alpha: alpha.to_f)
-    else
-      NSColor.colorWithCalibratedRed(red, green:green, blue:blue, alpha:alpha.to_f)
-    end
+    NSColor.rgba(red, green, blue, alpha.to_f)
   end
 
   def cgcolor(alpha=nil)

--- a/lib/osx/sugarcube-color/nsarray.rb
+++ b/lib/osx/sugarcube-color/nsarray.rb
@@ -8,7 +8,11 @@ class NSArray
     if self[3]
       alpha = self[3]
     end
-    NSColor.colorWithRed(red, green:green, blue:blue, alpha:alpha.to_f)
+    if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
+      NSColor.colorWithRed(red, green:green, blue:blue, alpha:alpha.to_f)
+    else
+      NSColor.colorWithCalibratedRed(red, green:green, blue:blue, alpha:alpha.to_f)
+    end
   end
 
   def cgcolor(alpha=nil)

--- a/lib/osx/sugarcube-color/nsarray.rb
+++ b/lib/osx/sugarcube-color/nsarray.rb
@@ -8,11 +8,7 @@ class NSArray
     if self[3]
       alpha = self[3]
     end
-    if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
-      NSColor.colorWithRed(red, green:green, blue:blue, alpha:alpha.to_f)
-    else
-      NSColor.colorWithCalibratedRed(red, green:green, blue:blue, alpha:alpha.to_f)
-    end
+    NSColor.rgba(red, green, blue, alpha.to_f)
   end
 
   def cgcolor(alpha=nil)

--- a/lib/osx/sugarcube-color/nscolor.rb
+++ b/lib/osx/sugarcube-color/nscolor.rb
@@ -59,7 +59,11 @@ class NSColor
     g = [1.0, color.green * color.alpha + self.green].min
     b = [1.0, color.blue * color.alpha + self.blue].min
     a = self.alpha
-    NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
+    if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
+      NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
+    else
+      NSColor.colorWithCalibratedRed(r, green:g, blue:b, alpha:a)
+    end
   end
 
   # a more generic color mixing method.  mixes two colors, but a second
@@ -80,7 +84,11 @@ class NSColor
       g = (self.green + color.green) / 2
       b = (self.blue + color.blue) / 2
       a = self.alpha
-      NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
+      if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
+        NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
+      else
+        NSColor.colorWithCalibratedRed(r, green:g, blue:b, alpha:a)
+      end
     else
       a = (color.alpha - self.alpha) * amount + self.alpha
       return NSColor.clearColor if a == 0
@@ -95,7 +103,11 @@ class NSColor
       r = (color_red - self_red) * amount + self_red
       g = (color_green - self_green) * amount + self_green
       b = (color_blue - self_blue) * amount + self_blue
-      NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
+      if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
+        NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
+      else
+        NSColor.colorWithCalibratedRed(r, green:g, blue:b, alpha:a)
+      end
     end
   end
 
@@ -107,7 +119,11 @@ class NSColor
     g = 1.0 - self.green
     b = 1.0 - self.blue
     a = self.alpha
-    NSColor.colorWithRed(r, green: g, blue: b, alpha: a)
+    if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
+      NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
+    else
+      NSColor.colorWithCalibratedRed(r, green:g, blue:b, alpha:a)
+    end
   end
 
   # Cannot define method `hue' because no Objective-C stub was pre-compiled for

--- a/lib/osx/sugarcube-color/nscolor.rb
+++ b/lib/osx/sugarcube-color/nscolor.rb
@@ -28,6 +28,14 @@ class NSColor
     end
   end
 
+  def self.rgba(r, g, b, a)
+    if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
+      NSColor.colorWithRed(r, green: g, blue: b, alpha: a)
+    else
+      NSColor.colorWithCalibratedRed(r, green: g, blue: b, alpha: a)
+    end
+  end
+
   def named_color_space?
     colorSpaceName == "NSNamedColorSpace"
   end
@@ -59,11 +67,8 @@ class NSColor
     g = [1.0, color.green * color.alpha + self.green].min
     b = [1.0, color.blue * color.alpha + self.blue].min
     a = self.alpha
-    if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
-      NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
-    else
-      NSColor.colorWithCalibratedRed(r, green:g, blue:b, alpha:a)
-    end
+
+    NSColor.rgba(r, g, b, a)
   end
 
   # a more generic color mixing method.  mixes two colors, but a second
@@ -84,11 +89,7 @@ class NSColor
       g = (self.green + color.green) / 2
       b = (self.blue + color.blue) / 2
       a = self.alpha
-      if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
-        NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
-      else
-        NSColor.colorWithCalibratedRed(r, green:g, blue:b, alpha:a)
-      end
+      NSColor.rgba(r, g, b, a)
     else
       a = (color.alpha - self.alpha) * amount + self.alpha
       return NSColor.clearColor if a == 0
@@ -103,11 +104,7 @@ class NSColor
       r = (color_red - self_red) * amount + self_red
       g = (color_green - self_green) * amount + self_green
       b = (color_blue - self_blue) * amount + self_blue
-      if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
-        NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
-      else
-        NSColor.colorWithCalibratedRed(r, green:g, blue:b, alpha:a)
-      end
+      NSColor.rgba(r, g, b, a)
     end
   end
 
@@ -119,11 +116,7 @@ class NSColor
     g = 1.0 - self.green
     b = 1.0 - self.blue
     a = self.alpha
-    if NSColor.respond_to?('colorWithRed:green:blue:alpha:')
-      NSColor.colorWithRed(r, green:g, blue:b, alpha:a)
-    else
-      NSColor.colorWithCalibratedRed(r, green:g, blue:b, alpha:a)
-    end
+    NSColor.rgba(r, g, b, a)
   end
 
   # Cannot define method `hue' because no Objective-C stub was pre-compiled for


### PR DESCRIPTION
```objective-c
+ (NSColor *)colorWithRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha
``` 

has been introduced on 10.9 

This PR add a test for NSColor responding to this method, otherwise call 

```objective-c
+ (NSColor *)colorWithCalibratedRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha
```

thanks