### PR TITLE
avoid crash with iOS9

### DIFF
--- a/lib/cocoa/sugarcube-foundation/nsstring.rb
+++ b/lib/cocoa/sugarcube-foundation/nsstring.rb
@@ -21,11 +21,7 @@ class NSString
   end
 
   def unescape_url
-    CFURLCreateStringByReplacingPercentEscapes(
-            nil,
-            self,
-            ""
-            )
+    self.stringByReplacingPercentEscapesUsingEncoding(NSUTF8StringEncoding)
   end
 
   def remove_accents


### PR DESCRIPTION
When run `rake spec' with iOS9, it causes a crash.
This patch should be avoid a crash.

This is related to http://hipbyte.myjetbrains.com/youtrack/issue/RM-943