### PR TITLE
Add `UIAlertController.prompt` method

### DIFF
--- a/lib/ios/sugarcube-factories/uialertcontroller.rb
+++ b/lib/ios/sugarcube-factories/uialertcontroller.rb
@@ -95,6 +95,23 @@ class UIAlertController
                                            })
     addAction action
   end
+
+  def self.prompt(controller, title, options = {}, more_options = {}, &block)
+    text_fields = []
+
+    alert = UIAlertController.alert(controller, title, options.merge(show: false), more_options) do |result|
+      next block.call(text_fields.first.text) if result == 'OK'
+      next block.call(nil)
+    end
+
+    alert.addTextFieldWithConfigurationHandler(->(s){ text_fields << s })
+
+    if options.fetch(:show, true)
+      controller.presentViewController(alert, animated: true, completion: nil)
+    end
+
+    alert
+  end
 end
 
 module SugarCube

--- a/spec/ios/uialertcontroller_spec.rb
+++ b/spec/ios/uialertcontroller_spec.rb
@@ -128,5 +128,14 @@ if defined?(UIAlertControllerStyleAlert)
       alert.actions[3].style.should == UIAlertActionStyleDefault
     end
 
+    describe '.prompt' do
+      it 'should have text_field' do
+        alert = UIAlertController.prompt(controller, 'test')
+        wait 0.6 do
+          alert.textFields.count.should == 1
+          controller.dismissViewControllerAnimated(false, completion: nil)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
`UIAlertController.alert` doesn't have an option to include text_field in alert window.
It would be nice to have an alert window that can receive user input. For example:

![image](https://user-images.githubusercontent.com/4011729/50057471-dc5fac80-01a5-11e9-98e7-d95924695016.png)

The idea of the name `prompt` comes from [javascript](https://www.w3schools.com/jsref/met_win_prompt.asp).
